### PR TITLE
Change some (required) marked fields

### DIFF
--- a/matchstart.fbs
+++ b/matchstart.fbs
@@ -298,14 +298,14 @@ table MatchSettings {
   /// Leave unset to tell RLBot to not launch the game
   launcher:Launcher;
   /// The path to the main Rocket League binary
-  game_path:string (required);
+  game_path:string;
   auto_start_bots:bool;
   /// The name of a upk file, like UtopiaStadium_P, which should be loaded.
   /// On Steam version of Rocket League this can be used to load custom map files,
   /// but on Epic version it only works on the Psyonix maps.
-  game_map_upk:string (required);
-  player_configurations:[PlayerConfiguration] (required);
-  script_configurations:[ScriptConfiguration] (required);
+  game_map_upk:string;
+  player_configurations:[PlayerConfiguration] = [];
+  script_configurations:[ScriptConfiguration] = [];
   game_mode:GameMode;
   skip_replays:bool;
   instant_start:bool;

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -214,11 +214,11 @@ table TeamInfo {
 }
 
 table GameTickPacket {
-  players:[PlayerInfo] (required);
-  boost_pads:[BoostPadState] (required);
-  balls:[BallInfo] (required);
+  players:[PlayerInfo] = [];
+  boost_pads:[BoostPadState] = [];
+  balls:[BallInfo] = [];
   game_info:GameInfo (required);
-  teams:[TeamInfo] (required);
+  teams:[TeamInfo] = [];
 }
 
 root_type GameTickPacket;


### PR DESCRIPTION
This allows `MatchSettings` and `GameTickPacket` to have Default implementations in the rust code generated by [planus](https://github.com/planus-org/planus?tab=readme-ov-file#planus--alternative-flatbuffer-implementation).