### PR TITLE
Implement group ids

### DIFF
--- a/matchstart.fbs
+++ b/matchstart.fbs
@@ -272,13 +272,13 @@ table MutatorSettings {
 }
 
 enum ExistingMatchBehavior : ubyte {
-  /// Restart the match if any match settings differ. This is the default because old RLBot always worked this way.
-  Restart_If_Different,
-  /// Always restart the match, even if config is identical
+  /// Always restart the match, even if config is identical.
   Restart,
   /// Never restart an existing match, just try to remove or spawn cars to match the configuration.
   /// If we are not in the middle of a match, a match will be started. Handy for LAN matches.
   Continue_And_Spawn,
+  /// Restart the match if any match settings differ.
+  Restart_If_Different,
 }
 
 enum Launcher : ubyte {

--- a/matchstart.fbs
+++ b/matchstart.fbs
@@ -72,11 +72,11 @@ table PlayerConfiguration {
   variety:PlayerClass (required);
   name:string (required);
   team:uint;
-  location:string (required);
+  root_dir:string (required);
   run_command:string (required);
   loadout:PlayerLoadout;
   spawn_id:int;
-  group_id:string (required);
+  agent_id:string (required);
   hivemind:bool;
 }
 
@@ -291,7 +291,7 @@ table ScriptConfiguration {
   location:string (required);
   run_command:string (required);
   spawn_id:int;
-  group_id:string (required);
+  agent_id:string (required);
 }
 
 table MatchSettings {

--- a/matchstart.fbs
+++ b/matchstart.fbs
@@ -50,7 +50,7 @@ table PlayerLoadout {
 }
 
 table SetLoadout {
-  spawn_id:int;
+  index:uint;
   loadout:PlayerLoadout (required);
 }
 
@@ -75,9 +75,8 @@ table PlayerConfiguration {
   location:string (required);
   run_command:string (required);
   loadout:PlayerLoadout;
-  /// In the case where the requested player index is not available, spawnId will help
-  /// the framework figure out what index was actually assigned to this player instead.
   spawn_id:int;
+  group_id:string (required);
   hivemind:bool;
 }
 
@@ -292,6 +291,7 @@ table ScriptConfiguration {
   location:string (required);
   run_command:string (required);
   spawn_id:int;
+  group_id:string (required);
 }
 
 table MatchSettings {

--- a/rendering.fbs
+++ b/rendering.fbs
@@ -12,7 +12,7 @@ enum TextVAlign: ubyte {
   Bottom,
 }
 
-table Color {
+struct Color {
   a:ubyte;
   r:ubyte;
   g:ubyte;

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -9,12 +9,13 @@ namespace rlbot.flat;
 /// This could be sent by a bot, or a bot manager governing several bots, an
 /// overlay, or any other utility that connects to the RLBot process.
 table ConnectionSettings {
+  /// The ID of the bot/script that is associated with the incoming connection.
   agent_id: string (required);
-  // If this is set, RLBot will send BallPrediction data back to the client when available.
+  /// If this is set, RLBot will send BallPrediction data back to the client when available.
   wants_ball_predictions:bool;
-  // If this is set, RLBot will send MatchComms to the client when available.
+  /// If this is set, RLBot will send MatchComms to the client when available.
   wants_comms:bool;
-  // If this is set, RLBot will close the connection after the match ends. The GUI will not want this
+  /// If this is set, RLBot will close the connection after the match ends. The GUI will not want this
   close_after_match:bool;
 }
 
@@ -24,7 +25,9 @@ table ControllableInfo {
 }
 
 table ControllableTeamInfo {
+  /// The assigned team for this connection
   team: uint;
+  /// The bots that RLBot will allow this connection to control
   controllables:[ControllableInfo] (required);
 }
 
@@ -172,6 +175,8 @@ table PlayerInfo {
   has_jumped:bool;
   has_double_jumped:bool;
   has_dodged:bool;
+  /// The time in seconds since the last dodge was initiated.
+  /// Resets to 0 when the player lands on the ground.
   dodge_elapsed:float;
   dodge_dir:Vector2 (required);
 }

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -166,7 +166,7 @@ table PlayerInfo {
   last_spectated:bool;
   has_jumped:bool;
   has_double_jumped:bool;
-  has_flipped:bool;
+  has_dodged:bool;
 }
 
 table BallInfo {

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -9,6 +9,7 @@ namespace rlbot.flat;
 /// This could be sent by a bot, or a bot manager governing several bots, an
 /// overlay, or any other utility that connects to the RLBot process.
 table ConnectionSettings {
+  group_id: string (required);
   // If this is set, RLBot will send BallPrediction data back to the client when available.
   wants_ball_predictions:bool;
   // If this is set, RLBot will send MatchComms to the client when available.
@@ -17,8 +18,14 @@ table ConnectionSettings {
   close_after_match:bool;
 }
 
-table InitComplete {
+table ControllableInfo {
+  index:uint;
   spawn_id:int;
+}
+
+table TeamControllables {
+  team: uint;
+  controllables:[ControllableInfo] (required);
 }
 
 table ControllerState {
@@ -139,8 +146,6 @@ table PlayerInfo {
   name:string (required);
   team:uint;
   boost:uint;
-  /// In the case where the requested player index is not available, spawnId will help
-  /// the framework figure out what index was actually assigned to this player instead.
   spawn_id:int;
   /// Notifications the player triggered by some in-game event, such as:
   ///    Win, Loss, TimePlayed;

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -9,7 +9,7 @@ namespace rlbot.flat;
 /// This could be sent by a bot, or a bot manager governing several bots, an
 /// overlay, or any other utility that connects to the RLBot process.
 table ConnectionSettings {
-  group_id: string (required);
+  agent_id: string (required);
   // If this is set, RLBot will send BallPrediction data back to the client when available.
   wants_ball_predictions:bool;
   // If this is set, RLBot will send MatchComms to the client when available.

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -56,6 +56,11 @@ table PlayerInput {
 
 root_type PlayerInput;
 
+struct Vector2 {
+  x:float;
+  y:float;
+}
+
 // Values are in "unreal units"
 struct Vector3 {
   x:float;
@@ -167,6 +172,8 @@ table PlayerInfo {
   has_jumped:bool;
   has_double_jumped:bool;
   has_dodged:bool;
+  dodge_elapsed:float;
+  dodge_dir:Vector2;
 }
 
 table BallInfo {

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -113,11 +113,11 @@ struct ScoreInfo {
   demolitions:uint;
 }
 
-table Physics {
-  location:Vector3 (required);
-  rotation:Rotator (required);
-  velocity:Vector3 (required);
-  angular_velocity:Vector3 (required);
+struct Physics {
+  location:Vector3;
+  rotation:Rotator;
+  velocity:Vector3;
+  angular_velocity:Vector3;
 }
 
 enum AirState: ubyte {
@@ -261,12 +261,12 @@ table FieldInfo {
 
 root_type FieldInfo;
 
-table PredictionSlice {
+struct PredictionSlice {
   /// The moment in game time that this prediction corresponds to.
   /// This corresponds to 'secondsElapsed' in the GameInfo table.
   game_seconds:float;
   /// The predicted location and motion of the object.
-  physics:Physics (required);
+  physics:Physics;
 }
 
 table BallPrediction {

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -164,6 +164,9 @@ table PlayerInfo {
   last_input:ControllerState (required);
   /// If the player was the last one to be watched by a spectator
   last_spectated:bool;
+  has_jumped:bool;
+  has_double_jumped:bool;
+  has_flipped:bool;
 }
 
 table BallInfo {

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -173,7 +173,7 @@ table PlayerInfo {
   has_double_jumped:bool;
   has_dodged:bool;
   dodge_elapsed:float;
-  dodge_dir:Vector2;
+  dodge_dir:Vector2 (required);
 }
 
 table BallInfo {

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -28,7 +28,7 @@ table TeamControllables {
   controllables:[ControllableInfo] (required);
 }
 
-table ControllerState {
+struct ControllerState {
   /// -1 for full reverse, 1 for full forward
   throttle:float;
   /// -1 for full left, 1 for full right
@@ -98,7 +98,7 @@ table Touch {
   ball_index:uint;
 }
 
-table ScoreInfo {
+struct ScoreInfo {
   score:uint;
   goals:uint;
   own_goals:uint;
@@ -174,7 +174,7 @@ table BallInfo {
   shape:CollisionShape (required);
 }
 
-table BoostPadState {
+struct BoostPadState {
   /// True if the boost can be picked up
   is_active:bool;
   /// The number of seconds since the boost has been picked up, or 0.0 if the boost is active.
@@ -215,7 +215,7 @@ table GameInfo {
   frame_num:uint;
 }
 
-table TeamInfo {
+struct TeamInfo {
   team_index:uint;
   /// number of goals scored.
   score:uint;

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -228,7 +228,7 @@ struct TeamInfo {
   score:uint;
 }
 
-table GameTickPacket {
+table GamePacket {
   players:[PlayerInfo] (required);
   boost_pads:[BoostPadState] (required);
   balls:[BallInfo] (required);
@@ -236,7 +236,7 @@ table GameTickPacket {
   teams:[TeamInfo] (required);
 }
 
-root_type GameTickPacket;
+root_type GamePacket;
 
 // This section deals with arena information, e.g. where the goals and boost locations are.
 

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -188,7 +188,7 @@ struct BoostPadState {
   timer:float;
 }
 
-enum GameStateType: ubyte {
+enum GameStatus: ubyte {
   /// Game has not been created yet
   Inactive,
   /// 3-2-1 countdown
@@ -212,7 +212,7 @@ table GameInfo {
   game_time_remaining:float;
   is_overtime:bool;
   is_unlimited_time:bool;
-  game_state_type:GameStateType;
+  game_status:GameStatus;
   world_gravity_z:float;
   /// Game speed multiplier, 1.0 is regular game speed.
   game_speed:float;

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -23,7 +23,7 @@ table ControllableInfo {
   spawn_id:int;
 }
 
-table TeamControllables {
+table ControllableTeamInfo {
   team: uint;
   controllables:[ControllableInfo] (required);
 }


### PR DESCRIPTION
- Implement group ids spec
  - Allows a static id to be sent to core upon connection & the team, spawn id & index to be returned to the bot over the network.
- Make `Restart` the default for `ExistingMatchBehavior`
  - Restart if different was broken in v4 and has confused some botmakers. Make `Restart` the default.
- Add `has_jumped`, `has_double_jumped`, `has_dodged`, `dodge_elapsed`, & `dodge_dir`