### PR TITLE
Various renamings

### DIFF
--- a/matchstart.fbs
+++ b/matchstart.fbs
@@ -22,7 +22,7 @@ table Psyonix {
 /// but is actually controlled by a bot.
 table PartyMember {}
 
-union PlayerClass { RLBot, Human, Psyonix, PartyMember }
+union PlayerClass { CustomBot, Human, Psyonix, PartyMember }
 
 /// The car type, color, and other aspects of the player's appearance.
 /// See https://wiki.rlbot.org/botmaking/bot-customization/

--- a/matchstart.fbs
+++ b/matchstart.fbs
@@ -288,7 +288,7 @@ enum Launcher : ubyte {
 
 table ScriptConfiguration {
   name:string (required);
-  location:string (required);
+  root_dir:string (required);
   run_command:string (required);
   spawn_id:int;
   agent_id:string (required);

--- a/matchstart.fbs
+++ b/matchstart.fbs
@@ -1,7 +1,7 @@
 namespace rlbot.flat;
 
 /// A bot controlled by the RLBot framework
-table RLBot {}
+table CustomBot {}
 
 /// A normal human player
 table Human {}

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -153,7 +153,7 @@ table PlayerInfo {
   is_supersonic:bool;
   is_bot:bool;
   name:string (required);
-  team:uint;
+  team:string (required);
   boost:uint;
   spawn_id:int;
   /// Notifications the player triggered by some in-game event, such as:

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -15,8 +15,9 @@ table ConnectionSettings {
   wants_ball_predictions:bool;
   /// If this is set, RLBot will send MatchComms to the client when available.
   wants_comms:bool;
-  /// If this is set, RLBot will close the connection after the match ends. The GUI will not want this
-  close_after_match:bool;
+  /// If this is set, RLBot will close the connection when a match is stopped or when a new
+  /// match is started. The GUI and other match runners should likely not set this.
+  close_between_matches:bool;
 }
 
 table ControllableInfo {

--- a/rlbot.fbs
+++ b/rlbot.fbs
@@ -153,7 +153,7 @@ table PlayerInfo {
   is_supersonic:bool;
   is_bot:bool;
   name:string (required);
-  team:string (required);
+  team:uint;
   boost:uint;
   spawn_id:int;
   /// Notifications the player triggered by some in-game event, such as:


### PR DESCRIPTION
- Renames `location` to `root_dir`. Resolves #31.
- Renames `close_after_match` to `close_between_matches` and add clarifying comment. Resolves #32.
- Renames `RLBot` to `CustomBot` to avoid name clashes with capitalized namespace.