### PR TITLE
Missing mutators

### DIFF
--- a/matchconfig.fbs
+++ b/matchconfig.fbs
@@ -174,7 +174,8 @@ enum BallTypeMutator : ubyte {
   Anniversary,
   Haunted,
   Ekin,
-  SpookyCube
+  SpookyCube,
+  Egg
 }
 
 /// Ball weight mutator options.
@@ -203,7 +204,14 @@ enum BallBouncinessMutator : ubyte {
   Low,
   High,
   SuperHigh,
-  LowishBounciness,
+  Lowish,
+}
+
+/// Ball gravity mutator options.
+enum BallGravityMutator: ubyte {
+  Default,
+  Low,
+  High
 }
 
 /// Boost amount mutator options.
@@ -275,7 +283,8 @@ enum MaxTimeMutator : ubyte {
 enum GameEventMutator : ubyte {
   Default,
   Haunted,
-  Rugby
+  Rugby,
+  Territory
 }
 
 /// Audio mutator options.
@@ -327,6 +336,8 @@ table MutatorSettings {
   game_event:GameEventMutator;
   /// Additional audio options for custom modes.
   audio:AudioMutator;
+  /// Ball gravity.
+  ball_gravity:BallGravityMutator;
 }
 
 /// Possible behaviours when a match is started while another match is in progress.

--- a/matchconfig.fbs
+++ b/matchconfig.fbs
@@ -298,6 +298,11 @@ enum TerritoryMutator : ubyte {
   Territory
 }
 
+enum StaleBallMutator : ubyte {
+  Default,
+  ThirtySeconds
+}
+
 /// All mutators options.
 table MutatorSettings {
   /// Duration of the match.
@@ -345,6 +350,8 @@ table MutatorSettings {
   ball_gravity:BallGravityMutator;
   /// Territory mutator.
   territory:TerritoryMutator;
+  /// Stale ball mutator.
+  stale_ball:StaleBallMutator;
 }
 
 /// Possible behaviours when a match is started while another match is in progress.

--- a/matchconfig.fbs
+++ b/matchconfig.fbs
@@ -211,7 +211,8 @@ enum BallBouncinessMutator : ubyte {
 enum BallGravityMutator: ubyte {
   Default,
   Low,
-  High
+  High,
+  SuperHigh
 }
 
 /// Boost amount mutator options.
@@ -283,14 +284,18 @@ enum MaxTimeMutator : ubyte {
 enum GameEventMutator : ubyte {
   Default,
   Haunted,
-  Rugby,
-  Territory
+  Rugby
 }
 
 /// Audio mutator options.
 enum AudioMutator : ubyte {
   Default,
   Haunted
+}
+
+enum TerritoryMutator : ubyte {
+  Default,
+  Territory
 }
 
 /// All mutators options.
@@ -338,6 +343,8 @@ table MutatorSettings {
   audio:AudioMutator;
   /// Ball gravity.
   ball_gravity:BallGravityMutator;
+  /// Territory mutator.
+  territory:TerritoryMutator;
 }
 
 /// Possible behaviours when a match is started while another match is in progress.

--- a/matchconfig.fbs
+++ b/matchconfig.fbs
@@ -123,6 +123,16 @@ enum MaxScoreMutator : ubyte {
   ThreeGoals,
   FiveGoals,
   SevenGoals,
+  TenGoals,
+  TwentyGoals,
+  ThirtyGoals,
+  FortyGoals,
+  FiftyGoals,
+  SixtyGoals,
+  SeventyGoals,
+  EightyGoals,
+  NinetyGoals,
+  HundredGoals,
   Unlimited
 }
 
@@ -175,7 +185,10 @@ enum BallTypeMutator : ubyte {
   Haunted,
   Ekin,
   SpookyCube,
-  Egg
+  Egg,
+  PlayerSeeking,
+  Dropshot,
+  ScoreAbsorb
 }
 
 /// Ball weight mutator options.
@@ -236,7 +249,9 @@ enum RumbleMutator : ubyte {
   SpikeRush,
   HauntedBallBeam,
   Tactical,
-  BatmanRumble
+  BatmanRumble,
+  GrapplingOnly,
+  HaymakerOnly,
 }
 
 /// Boost strength mutator options.
@@ -263,7 +278,9 @@ enum DemolishMutator : ubyte {
   Disabled,
   FriendlyFire,
   OnContact,
-  OnContactFF
+  OnContactFF,
+  OnBallContact,
+  OnBallContactFF
 }
 
 /// Respawn time mutator options.
@@ -303,6 +320,62 @@ enum StaleBallMutator : ubyte {
   ThirtySeconds
 }
 
+enum JumpMutator : ubyte {
+  Default,
+  Grounded,
+  Two,
+  Three,
+  Four,
+  Unlimited,
+  NoJumps
+}
+
+enum DodgeTimerMutator : ubyte {
+  Default,
+  TwoSeconds,
+  ThreeSeconds,
+  Unlimited
+}
+
+enum PossessionScoreMutator : ubyte {
+  Default,
+  OneSecond,
+  TwoSeconds,
+  ThreeSeconds
+}
+
+enum DemolishScoreMutator : ubyte {
+  Default,
+  One,
+  Two,
+  Three
+}
+
+enum NormalGoalScoreMutator : ubyte {
+  Default,
+  Zero,
+  Two,
+  Three,
+  Five,
+  Ten
+}
+
+enum AerialGoalScoreMutator : ubyte {
+  Default,
+  Zero,
+  Two,
+  Three,
+  Five,
+  Ten
+}
+
+enum AssistGoalScoreMutator : ubyte {
+  Default,
+  One,
+  Two,
+  Three
+}
+
 /// All mutators options.
 table MutatorSettings {
   /// Duration of the match.
@@ -313,7 +386,7 @@ table MutatorSettings {
   multi_ball:MultiBallMutator;
   /// The overtime rules and tiebreaker.
   overtime:OvertimeMutator;
-  /// The series length (unsupported).
+  /// The series length.
   series_length:SeriesLengthMutator;
   /// A game speed multiplier.
   game_speed:GameSpeedMutator;
@@ -352,6 +425,20 @@ table MutatorSettings {
   territory:TerritoryMutator;
   /// Stale ball mutator.
   stale_ball:StaleBallMutator;
+  /// Jumps mutator.
+  jump:JumpMutator;
+  /// Dodge timer mutator.
+  dodge_timer:DodgeTimerMutator;
+  /// Possession score mutator.
+  possession_score:PossessionScoreMutator;
+  /// Demolish score mutator.
+  demolish_score:DemolishScoreMutator;
+  /// Normal goal score mutator.
+  normal_goal_score:NormalGoalScoreMutator;
+  /// Aerial goal score mutator.
+  aerial_goal_score:AerialGoalScoreMutator;
+  /// Assist goal score mutator.
+  assist_goal_score:AssistGoalScoreMutator;
 }
 
 /// Possible behaviours when a match is started while another match is in progress.

--- a/matchconfig.fbs
+++ b/matchconfig.fbs
@@ -376,6 +376,11 @@ enum AssistGoalScoreMutator : ubyte {
   Three
 }
 
+enum InputRestrictionMutator : ubyte {
+  Default,
+  Backwards
+}
+
 /// All mutators options.
 table MutatorSettings {
   /// Duration of the match.
@@ -439,6 +444,8 @@ table MutatorSettings {
   aerial_goal_score:AerialGoalScoreMutator;
   /// Assist goal score mutator.
   assist_goal_score:AssistGoalScoreMutator;
+  /// Player input restriction mutator.
+  input_restriction:InputRestrictionMutator;
 }
 
 /// Possible behaviours when a match is started while another match is in progress.


### PR DESCRIPTION
Renames the `LowishBounciness` to `Lowish` to make it inline with the others
Adds `BallGravityMutator`
Adds `Egg` to `BallTypeMutator`
New `Territory` in `TerritoryMutator`
New `ThirtySeconds` in `StaleBallMutator`

& the various new S18 mutators