### PR TITLE
Make CoreMessage and InterfaceMessage requried in respective packet table

### DIFF
--- a/schema/corepacket.fbs
+++ b/schema/corepacket.fbs
@@ -29,7 +29,7 @@ union CoreMessage {
 
 /// Packet containing a CoreMessage
 table CorePacket {
-  message: CoreMessage;
+  message: CoreMessage (required);
 }
 
 root_type CorePacket;

--- a/schema/interfacepacket.fbs
+++ b/schema/interfacepacket.fbs
@@ -50,7 +50,7 @@ union InterfaceMessage {
 
 /// Packet containing a InterfaceMessage
 table InterfacePacket {
-  message: InterfaceMessage;
+  message: InterfaceMessage (required);
 }
 
 root_type InterfacePacket;


### PR DESCRIPTION
Mark with `(required)`. Removes the Option<> wrapper in rust/planus.