### PR TITLE
Removed circular dependency in schema includes

### DIFF
--- a/schema/color.fbs
+++ b/schema/color.fbs
@@ -1,0 +1,9 @@
+namespace rlbot.flat;
+
+/// An RGBA color.
+struct Color {
+  r: ubyte;
+  g: ubyte;
+  b: ubyte;
+  a: ubyte;
+}

--- a/schema/gamedata.fbs
+++ b/schema/gamedata.fbs
@@ -1,4 +1,4 @@
-include "matchconfig.fbs";
+include "vector.fbs";
 
 namespace rlbot.flat;
 
@@ -40,20 +40,6 @@ struct ControllerState {
 table PlayerInput {
   player_index: uint;
   controller_state: ControllerState (required);
-}
-
-/// A vector with an x and y component.
-struct Vector2 {
-  x: float;
-  y: float;
-}
-
-/// A vector with an x, y, z component.
-/// Note that Rocket League uses a left-handed coordinate system.
-struct Vector3 {
-  x: float;
-  y: float;
-  z: float;
 }
 
 /// Expresses the rotation state of an object in Euler angles. Values are in radians.

--- a/schema/matchconfig.fbs
+++ b/schema/matchconfig.fbs
@@ -1,4 +1,4 @@
-include "rendering.fbs";
+include "color.fbs";
 
 namespace rlbot.flat;
 

--- a/schema/rendering.fbs
+++ b/schema/rendering.fbs
@@ -1,4 +1,5 @@
-include "gamedata.fbs";
+include "color.fbs";
+include "vector.fbs";
 
 namespace rlbot.flat;
 
@@ -14,14 +15,6 @@ enum TextVAlign: ubyte {
   Top,
   Center,
   Bottom,
-}
-
-/// An RGBA color.
-struct Color {
-  r: ubyte;
-  g: ubyte;
-  b: ubyte;
-  a: ubyte;
 }
 
 /// A RenderAnchor attached to a ball.

--- a/schema/vector.fbs
+++ b/schema/vector.fbs
@@ -1,0 +1,17 @@
+include "vector.fbs";
+
+namespace rlbot.flat;
+
+/// A vector with an x and y component.
+struct Vector2 {
+  x: float;
+  y: float;
+}
+
+/// A vector with an x, y, z component.
+/// Note that Rocket League uses a left-handed coordinate system.
+struct Vector3 {
+  x: float;
+  y: float;
+  z: float;
+}


### PR DESCRIPTION
Removes a circular dependency between schema files that caused flatcc to fail generating code.

`gamedata.fbs` does not actually depend on `matchconfig.fbs`, so removing this include fixes the circular dependency.

For completion, also moved generic tables to separate schema files, to clean up most of the remaining include statements.